### PR TITLE
Fix issue with how ODOOADDONS in odoo.tools

### DIFF
--- a/odoo.tools
+++ b/odoo.tools
@@ -4,5 +4,5 @@
 # ODOORESTART=<special odoo restart command>
 # ODOORESTART="sudo service odoo restart && sudo service apache2 restart"
 # List addons directories in ODOOADDONS-variable
-export ODOOADDONS=`ls -d /usr/share/odoo-* | grep -v odoo-addons | tr "\n" ","`
-#export ODOOADDONS=`ls -d /usr/share/odoo-* /usr/share/odooext-* | grep -v odoo-addons | tr "\n" ","`
+#export ODOOADDONS=`ls -d /usr/share/odoo-* | grep -v odoo-addons | tr "\n" ","`
+export ODOOADDONS=`ls -d /usr/share/odoo-* /usr/share/odooext-* 2> /dev/null | grep -v odoo-addons | paste -sd ","`


### PR DESCRIPTION
Update the definition of ODOOADDONS in odoo.tools such that it handles
- Empty directories (such as no odooext)
- No comma at end-of-line